### PR TITLE
Tcp error handling

### DIFF
--- a/lib/components/tcp/index.ts
+++ b/lib/components/tcp/index.ts
@@ -65,13 +65,10 @@ export class TcpSource extends Source {
           })
 
           socket.on('data', buffer => {
-            try {
-              if (!incoming.push({ data: buffer, type: MessageType.RAW })) {
-                console.warn('TCP Component internal error: not allowed to push more data',)
-              }
-            }
-            catch (e) {
-              console.warn('Error when pushing to readable stream',)
+            if (!incoming.push({ data: buffer, type: MessageType.RAW })) {
+              console.warn(
+                'TCP Component internal error: not allowed to push more data',
+              )
             }
           })
           // When closing a socket, indicate there is no more data to be sent,

--- a/lib/components/tcp/index.ts
+++ b/lib/components/tcp/index.ts
@@ -92,7 +92,7 @@ export class TcpSource extends Source {
     })
 
     // When there is no more data going to be written, close!
-    outgoing.on('finish', () => {
+    outgoing.on('end', () => {
       socket && socket.end()
     })
 


### PR DESCRIPTION

Fixed TCP socket event handling: to handle FIN packets received on the TCP socket the event 'end' needs to be handled instead of 'finish'.